### PR TITLE
Include tests directory in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include README.rst
 
 recursive-include example *.c *.py
+recursive-include tests *.py
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
This PR adds the `tests/` directory to the `MANIFEST.in` template, so that it is included in source distributions, allowing downstream packagers to test their packages.